### PR TITLE
Fix links without href check

### DIFF
--- a/src/body/index.js
+++ b/src/body/index.js
@@ -36,7 +36,7 @@ const hasLinksText = () => {
 
 const hasLinksHref = () => {
   const LINKS = [...getElements('a')];
-  const linksWithoutHref = LINKS.filter(link => (isEmpty(getAttribute(link, 'href')) || !hasAttribute(link, 'href')) && !hasAttribute(link, 'role'));
+  const linksWithoutHref = LINKS.filter(link => (!hasAttribute(link, 'href') || isEmpty(getAttribute(link, 'href'))) && !hasAttribute(link, 'role'));
   const hasMissingHref = linksWithoutHref.length > 0;
   const withoutHrefWarning = linksWithoutHref.forEach(link => Warning(`Link Href is missing. Fix: Add href="LINK URL" to ${link.outerHTML}`));
 


### PR DESCRIPTION
Currently `linksWithoutHref` throws an exception when it encounters a link without an href attribute, as the `null` value that is returned from `getAttribute(link, 'href')` chokes on `.trim()`.

The fix in this PR simply reverses the order of the test so that `hasAttribute` is called first, which ensures that a string value will always be provided.